### PR TITLE
fix(ws): Styling fixes

### DIFF
--- a/workspaces/frontend/src/app/pages/Workspaces/Creation/WorkspaceCreation.tsx
+++ b/workspaces/frontend/src/app/pages/Workspaces/Creation/WorkspaceCreation.tsx
@@ -87,7 +87,7 @@ const WorkspaceCreation: React.FunctionComponent = () => {
           </ProgressStepper>
         </PageSection>
       </PageGroup>
-      <PageSection isFilled style={{ height: '100%' }}>
+      <PageSection isFilled>
         {currentStep === WorkspaceCreationSteps.KindSelection && <WorkspaceCreationKindSelection />}
         {currentStep === WorkspaceCreationSteps.ImageSelection && (
           <WorkspaceCreationImageSelection />

--- a/workspaces/frontend/src/shared/style/MUI-theme.scss
+++ b/workspaces/frontend/src/shared/style/MUI-theme.scss
@@ -732,6 +732,10 @@
   box-shadow: var(--mui-shadows-1);
 }
 
+.mui-theme .pf-v6-c-page__main-group.pf-m-sticky-top {
+  flex-grow: 0;
+}
+
 .mui-theme .pf-v6-c-pagination {
   --pf-v6-c-pagination__total-items--Display: block;
 }


### PR DESCRIPTION
Towards https://github.com/kubeflow/notebooks/pull/227

Updates:

- Removed `height: 100%` to resolve scroll issue and make sure the sticky bottom page section stays fixed to the bottom of the page container.
- Applies `flex-grow: 0` to the page group containing the progress stepper preventing additional white space caused by the flex growth.

Before:
<img width="1728" alt="Screenshot 2025-03-19 at 2 46 54 PM" src="https://github.com/user-attachments/assets/92829933-d0c7-44fa-85f1-fbee3dbdbd2c" />
<img width="1728" alt="Screenshot 2025-03-19 at 2 47 57 PM" src="https://github.com/user-attachments/assets/601649f3-f89b-48b6-9ea5-016d25bf7897" />

After:
<img width="1728" alt="Screenshot 2025-03-19 at 2 47 25 PM" src="https://github.com/user-attachments/assets/7e9f186a-2c66-4862-95cf-e6353ffccad2" />
<img width="1728" alt="Screenshot 2025-03-19 at 2 45 40 PM" src="https://github.com/user-attachments/assets/4ca8f410-f6ed-417a-bd72-41d993eed062" />